### PR TITLE
stmtflow: fix some bugs

### DIFF
--- a/tools/stmtflow/core/diff.go
+++ b/tools/stmtflow/core/diff.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 )
 
-func LocalDiff(w io.Writer, name string, txt1 string, txt2 string, color bool) error {
+func LocalDiff(w io.Writer, name string, txt1 string, txt2 string, diff []string) error {
+	if len(diff) == 0 {
+		diff = []string{"diff", "-u", "-N", "--color"}
+	}
 	name = strings.ReplaceAll(name, string(filepath.Separator), "__")
 	dir, err := ioutil.TempDir("", name+".")
 	if err != nil {
@@ -17,22 +20,19 @@ func LocalDiff(w io.Writer, name string, txt1 string, txt2 string, color bool) e
 	}
 	defer os.RemoveAll(dir)
 
-	args := []string{"-u", "-N"}
-	if color {
-		args = append(args, "--color")
-	}
 	path1 := filepath.Join(dir, "a")
 	if err = ioutil.WriteFile(path1, []byte(txt1), 0644); err != nil {
 		return err
 	}
-	args = append(args, path1)
+	diff = append(diff, path1)
 
 	path2 := filepath.Join(dir, "b")
 	if err = ioutil.WriteFile(path2, []byte(txt2), 0644); err != nil {
 		return err
 	}
-	args = append(args, path2)
-	cmd := exec.Command("diff", args...)
+	diff = append(diff, path2)
+
+	cmd := exec.Command(diff[0], diff[1:]...)
 	cmd.Stdout = w
 	return cmd.Run()
 }


### PR DESCRIPTION
1. all tests shared a single db instance previously, thus conns may be reused, which may lead to some undetermined issues.
2. common options like block time did take effect for test sub-command because we call `c.EvalOptions()` before parsing flags.
3. not all versions of diff support the `--color` option, thus allow customizing diff command (eg. use colordiff instead).

Signed-off-by: zyguan <zhongyangguan@gmail.com>